### PR TITLE
Adapt paralax section for small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,15 +40,15 @@
 				<div class="slider-container">
 					<div class="slider-container-text">
 						<h1 class="slider-header">Expire</h1>
-						<svg width="200px" height="60px" viewBox="0 0 100 1">
+						<svg class="slider-svg" width="200px" height="60px" viewBox="0 0 100 1">
 							<polyline class="polyline" points="0 0, 48 0, 52 4, 110 4" />	
 						</svg>
 						<p class="slider-description">Professionaly designed, carefully made for your enjoyement</p>
 						<a class="link-button slider-button" href="">explore</a>
 						<a class="link-button slider-button" href="">learn more</a>
 					</div>
-					<a href="" class="arrow left slider"></a>
-					<a href="" class="arrow right slider"></a>
+					<a href="" class="arrow left slider hidden-medium"></a>
+					<a href="" class="arrow right slider hidden-medium"></a>
 				</div>
 				<ul class="pagination-container">
 					<li class="pagination active"></li>

--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -113,7 +113,7 @@
         transform: rotate(135deg);
       }
       &:nth-child(3) {
-        visibility: hidden;
+        opacity: 0;
       }
     }
   }

--- a/scss/components/_navigation.scss
+++ b/scss/components/_navigation.scss
@@ -113,7 +113,7 @@
         transform: rotate(135deg);
       }
       &:nth-child(3) {
-        display: none;
+        visibility: hidden;
       }
     }
   }

--- a/scss/components/_paralax.scss
+++ b/scss/components/_paralax.scss
@@ -183,8 +183,8 @@
   
       .paralax-info-item {
         float: none;
-        width: 80%;
-        margin: 0 auto;
+        width: 100%;
+        padding-left: 50px;
         margin-bottom: 50px;
 
         .info-item-count {

--- a/scss/components/_paralax.scss
+++ b/scss/components/_paralax.scss
@@ -137,3 +137,66 @@
     }
   }
 }
+
+@include screen-medium {
+  .paralax-container {
+
+    .paralax-header {
+      font-size: 35px;
+      padding-top: 50px;
+    }
+  
+    .paralax-description {
+      padding-top: 40px;
+    }
+  
+    .paralax-blockquote-container {
+      padding-top: 50px;
+      padding-left: 20px;
+      letter-spacing: 0;
+  
+      .paralax-blockquote-text {
+        font-size: 28px;
+        line-height: 38px;
+  
+        &::before {
+          font-size: 90px;
+          top: 220px;
+          left: 0;
+        }
+      }
+  
+      .paralax-blockquote-author {
+        font-size: 25px;
+        padding-top: 35px;
+        padding-bottom: 70px;
+      }
+    }
+  }
+  
+  .paralax-info-block {
+  
+    .paralax-info-container {
+      padding-top: 90px;
+      padding-bottom: 20px;
+      padding-left: 0;
+  
+      .paralax-info-item {
+        float: none;
+        width: 80%;
+        margin: 0 auto;
+        margin-bottom: 50px;
+
+        .info-item-count {
+          color: $color-text-white;
+          margin-left: 28px;
+          font-size: 40px;
+        }
+  
+        .info-item-description {
+          margin-top: 0;
+        }
+      }
+    }
+  }
+}

--- a/scss/components/_slider.scss
+++ b/scss/components/_slider.scss
@@ -7,7 +7,6 @@
   padding-top: 180px;
   padding-bottom: 60px;
   max-width: $page-width;
-  height: 100%;
   margin: 0 auto;
 
   .slider-container-text {
@@ -79,5 +78,45 @@
     &:hover {
       background-color: $color-text-white;
     }
+  }
+}
+
+@include screen-medium {
+  .slider-container {
+    padding-top: 60px;
+  
+    .slider-container-text {
+      padding: 0;
+      padding-left: 20px;
+  
+      .slider-header {
+        font-size: 50px;
+      }
+  
+      .slider-description {
+        letter-spacing: 0;
+        line-height: 1;
+        font-size: 30px;
+      }
+  
+      .slider-button {
+        display: block;
+        margin-left: 0;
+        margin-bottom: 20px;
+      }
+  
+      .slider-button + .slider-button {
+        margin-left: 0;
+      }
+    }
+  }
+  
+  .slider-svg {
+    width: 150px;
+    height: 30px;
+  }
+  
+  .pagination-container {
+    margin: 5px auto 0;
   }
 }


### PR DESCRIPTION
Adjust paralax sections to fit small devices

- Adjust paddings and margins
- Adjust font sizes, line heights and letter-spacing
- Info section rework
  - Make info items behave like blocks
  - Adjust paddings and margins

Branched [from]( https://github.com/MxWoodie/hiqo-zhodik-markup/pull/10)